### PR TITLE
feat: retry navigation if aborted

### DIFF
--- a/app/r1Obr-orchestrator/conf/r1Obr-orchestrator_R1_erzelli.ini
+++ b/app/r1Obr-orchestrator/conf/r1Obr-orchestrator_R1_erzelli.ini
@@ -10,6 +10,7 @@ positive_feedback_port      /r1Obr-orchestrator/positive_outcome_feedback:i
 audioplayer_input_port      /r1Obr-orchestrator/chatBot/audioplayerStatus:i
 map_prefix                  erzelli_
 sensor_network_active       true
+max_retries                 1
 ; sensor_network_language     ita
 
 [OUTPUT_PORT_GROUP]

--- a/modules/r1Obr-orchestrator/include/orchestratorThread.h
+++ b/modules/r1Obr-orchestrator/include/orchestratorThread.h
@@ -115,6 +115,11 @@ private:
     bool                    m_going_home;
     string                  m_map_prefix;
 
+    // Navigation
+    string                  m_current_destination;
+    size_t                  m_current_retries = 0;
+    size_t                  m_max_retries = 1;
+
     ResourceFinder&         m_rf;
 
 public:

--- a/modules/r1Obr-orchestrator/src/orchestratorThread.cpp
+++ b/modules/r1Obr-orchestrator/src/orchestratorThread.cpp
@@ -55,6 +55,7 @@ bool OrchestratorThread::threadInit()
     if (m_rf.check("goandfindit_result_port"))  {m_goandfindit_result_port_name   = m_rf.find("goandfindit_result_port").asString();}
     if (m_rf.check("faceexpression_rpc_port"))  {m_faceexpression_rpc_port_name   = m_rf.find("faceexpression_rpc_port").asString();}
     if (m_rf.check("sn_feedback_port"))         {m_sn_feedback_port_name          = m_rf.find("sn_feedback_port").asString();}
+    if (m_rf.check("max_retries"))              {m_max_retries                    = m_rf.find("max_retries").asInt32();}
 
     if(m_rf.check("map_prefix")){m_map_prefix = m_rf.find("map_prefix").asString();}
 
@@ -63,7 +64,7 @@ bool OrchestratorThread::threadInit()
         return false;
     }
 
-    if(!m_nextLoc_rpc_port.open(m_nextLoc_rpc_port_name)){
+    if(!m_nextLoc_rpc_port.open(m_nextLoconfigure(c_rpc_port_name)){
         yCError(R1OBR_ORCHESTRATOR_THREAD) << "Cannot open nextLocPlanner RPC port with name" << m_nextLoc_rpc_port_name;
         return false;
     }
@@ -332,6 +333,14 @@ void OrchestratorThread::run()
 
             if (nav_aborted)
             {
+                // We ask the robot to retry to navigate to the current target.
+                // CAREFUL: the robot might not stop the first time you ask it to stop, to be checked
+                if (m_current_retries < m_max_retries)
+                {
+                    go(m_current_destination);
+                    m_current_retries++;
+                }
+                m_current_retries = 0;
                 askChatBotToSpeak(go_target_not_reached);
                 m_status = R1_IDLE;
             }
@@ -952,6 +961,7 @@ bool OrchestratorThread::go(string loc)
 
     m_status = R1_GOING;
     m_going = true;
+    m_current_destination = loc;
     return m_nav2loc->go(loc);
 }
 


### PR DESCRIPTION
Now r1 retries to navigate if navigation is aborted. This is a workaround to nav2 aborting navigation for seemingly unknown reasons. To be tested on the real robot, 