### PR TITLE
fix: reverting change to path workaround for erzelli break area

### DIFF
--- a/modules/r1Obr-orchestrator/src/nav2loc.cpp
+++ b/modules/r1Obr-orchestrator/src/nav2loc.cpp
@@ -125,14 +125,6 @@ bool Nav2Loc::go(string loc)
         }
         // If we are inside the lab area, we swap to the default behaviour
     }
-    else if (loc == "erzelli_break_area")
-    {
-        if(!m_iNav2D->gotoTargetByLocationName("erzelli_break_path"))
-        {
-            yCError(NAV_2_LOC, "Error with navigation to erzelli break area from outside");
-            return false;
-        }
-    }
 
     if(!m_iNav2D->gotoTargetByLocationName(loc))
     {


### PR DESCRIPTION
We revert this change since modifying the map helped fixing the navigation to the area and this creates unnecessary noise now